### PR TITLE
Autoconfigure path in shell profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.python-version

--- a/README.md
+++ b/README.md
@@ -7,32 +7,34 @@ author: <a href="https://www.linkedin.com/in/chris-torok/">Chris Torok</a>
 Get your project up and running now!
 
 ### Features & Benefits
+
 - Isolates your Python project
 - Automatic Virtual Environment activation
 - Less time for setup, more time for development
+- <b>new!</b> Automated PATH configuration. 
 
 
 ### Requires
 
 - Install `gcc`,`make` & `brew`
 - Give execution privileges to the install script `chmod +x install.sh`
-- Add a few lines to your shell profile.
 
 
 ### Use
+#### Quick install!
 
-Quick install!
 ```shell
 source <(curl -s https://raw.githubusercontent.com/theTisrock/pythonprojectinstall/master/install.sh) 3.12.0
 ```
 Replace the last arg with whichever Python version you need.
+
+#### Local Install!
 
 In your favorite terminal application...
 1. Copy the install script or clone this directory into your project: `cp pythonprojectinstall/install.sh myproject`
 2. Make the install script executable: `chmod +x myproject/install.sh`
 3. Make sure your project's `requirements.txt` are present under your project's root directory: `myproject/requirements.txt`
 4. Run the installation and provide your desired Python version: `./install.sh 3.12.0`
-5. Follow post installation instructions that appear when the script finishes. (you'll only have to do this once)
 
 ### Congrats!
 

--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,8 @@
 
 PYTHON_VERSION=$1
 PROJECT_NAME=$(basename $(pwd))
+# get shell name
+shell=$(echo "$SHELL" | rev | cut -d '/' -f 1 | rev)
 
 
 echo "Installation implemented for MacOS+zsh and Linux+bash"
@@ -113,6 +115,23 @@ echo ""
 echo "installing your requirements.txt ..."
 pip install -r requirements.txt
 echo "...done installing your requirements.txt"
+echo ""
+
+echo "Configuring the pyenv path..."
+echo "${shell}"
+if ["${shell}" == "bash"]
+then
+  # check file for path contents
+  # if contents are present, finish install
+  # if contents are not present, add them
+fi
+
+
+if ["${shell}" == "zsh"]
+then
+
+fi
+echo "...finished configuring pyenv path."
 
 
 echo ""

--- a/install.sh
+++ b/install.sh
@@ -145,6 +145,7 @@ eval "$(pyenv init -)"' >> $HOME/.zshrc
   fi
 fi
 echo "...finished configuring pyenv path."
+echo ""
 echo "installation complete!"
 echo ""
 echo "* type 'exec \$SHELL' OR close and reopen this command prompt."

--- a/install.sh
+++ b/install.sh
@@ -117,38 +117,34 @@ pip install -r requirements.txt
 echo "...done installing your requirements.txt"
 echo ""
 
-echo "Configuring the pyenv path..."
-echo "${shell}"
-if ["${shell}" == "bash"]
-then
+echo "Configuring the pyenv path for ${shell}"
+if [[ $shell == "bash" ]]; then
   # check file for path contents
-  # if contents are present, finish install
-  # if contents are not present, add them
-fi
+  grep '# pyenv
+  export PATH="$HOME/.pyenv/bin:$PATH"
+  eval "$(pyenv init --path)"
+  eval "$(pyenv virtualenv-init -)"' $HOME/.bashrc
 
-
-if ["${shell}" == "zsh"]
-then
-
-fi
-echo "...finished configuring pyenv path."
-
-
-echo ""
-echo "----- POST INSTALL INSTRUCTIONS -----"
-echo 'zsh/MacOS shell users, add the following contents to your ~/.zshrc file:'
-echo '
-export PYENV_ROOT="${HOME}/.pyenv"
-command -v pyenv >/dev/null || export PATH="${PYENV_ROOT}/bin:${PATH}"
-eval "$(pyenv init -)"
-'
-echo ''
-echo 'bash/Linux shell users, add the following contents to your ~/.bashrc file:'
-echo '
+  if [[ $? -ne 0 ]]; then
+    echo '# pyenv
 export PATH="$HOME/.pyenv/bin:$PATH"
 eval "$(pyenv init --path)"
-eval "$(pyenv virtualenv-init -)"
-'
-echo ''
+eval "$(pyenv virtualenv-init -)"' >> $HOME/.bashrc
+  fi
+elif [[ $shell == 'zsh' ]]; then
+  grep '# pyenv
+  export PYENV_ROOT="${HOME}/.pyenv"
+  command -v pyenv >/dev/null || export PATH="${PYENV_ROOT}/bin:${PATH}"
+  eval "$(pyenv init -)"' $HOME/.zshrc
 
+  if [[ $? -ne 0 ]]; then
+    echo '# pyenv
+export PYENV_ROOT="${HOME}/.pyenv"
+command -v pyenv >/dev/null || export PATH="${PYENV_ROOT}/bin:${PATH}"
+eval "$(pyenv init -)"' >> $HOME/.zshrc
+  fi
+fi
+echo "...finished configuring pyenv path."
+echo "installation complete!"
+echo ""
 echo "* type 'exec \$SHELL' OR close and reopen this command prompt."

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,9 @@ echo ""
 
 echo "Configuring the pyenv path for ${shell}"
 if [[ $shell == "bash" ]]; then
+  if [[ ! -f $HOME/.bashrc ]]; then
+    touch $HOME/.bashrc
+  fi
   # check file for path contents
   grep '# pyenv
   export PATH="$HOME/.pyenv/bin:$PATH"
@@ -132,6 +135,9 @@ eval "$(pyenv init --path)"
 eval "$(pyenv virtualenv-init -)"' >> $HOME/.bashrc
   fi
 elif [[ $shell == 'zsh' ]]; then
+  if [[ ! -f $HOME/.zshrc ]]; then
+    touch $HOME/.zshrc
+  fi
   grep '# pyenv
   export PYENV_ROOT="${HOME}/.pyenv"
   command -v pyenv >/dev/null || export PATH="${PYENV_ROOT}/bin:${PATH}"


### PR DESCRIPTION
Adds idempotent Zsh or Bash path information to the shell profile configuration file. If the configuration file does not exist, it is created.

Tested successfully on MacOs/zsh and Linux/bash.