### PR TITLE
[bug]: shell exits unexpectedly upon failed import when script is executed with "source" command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -80,7 +80,8 @@ echo ""
 echo "testing the project python virtual environment ..."
 pip install --no-cache-dir requests
 python -c "import requests;"
-if [ $? -ne 0 ]
+import_error_code=$?
+if [ $import_error_code -ne 0 ]
 then
   echo "Python failed to import the 'requests' dependency. This means that Python cannot see the packages associated with this project."
   echo ""
@@ -101,9 +102,8 @@ eval "$(pyenv virtualenv-init -)"
   echo ''
   echo "Rerun the installation once you have configured your PATH."
   echo "Stopping installation."
-
-
-  exit $?
+  return $import_error_code
+  exit $import_error_code
 fi
 echo "Python dependency imported successfully!"
 echo "Removing the test dependency"
@@ -155,3 +155,4 @@ echo ""
 echo "installation complete!"
 echo ""
 echo "* type 'exec \$SHELL' OR close and reopen this command prompt."
+


### PR DESCRIPTION
Triggering Issue: the requests package requires the use of a module called “[queue.py](http://queue.py/)” but is instead using a “[queue.py](http://queue.py/)” in the project directory. The script closes the entire shell window instead of remaining in the window for further troubleshooting.

Discovery & Troubleshooting:
used a temporary install.sh.log file that creates a fresh log for each run.
inspect the error message and figure out how to stop exit the shell window and instead just exit the script.
Researched alternative forms of stopping script execution.

Root Cause: shell window exit caused by using 'exit' command inside the script when executing the script with the “source” command.

Solution: script now uses a “return” keyword first when paired with “source” execution.

Result: Success!

The script halts execution with the window still present.

https://trello.com/c/4K2GfYdC/7-unexpected-exit-at-virtualenv-testing